### PR TITLE
Update ReactDOMFizzInstructionSetShared.js

### DIFF
--- a/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetShared.js
+++ b/packages/react-dom-bindings/src/server/fizz-instruction-set/ReactDOMFizzInstructionSetShared.js
@@ -30,7 +30,8 @@ const TARGET_VANITY_METRIC = 2300;
 // urgent issue.
 
 export function revealCompletedBoundaries(batch) {
-  window['$RT'] = performance.now();
+  let hasUpdatedRevealTime = false;
+  
   for (let i = 0; i < batch.length; i += 2) {
     const suspenseIdNode = batch[i];
     const contentNode = batch[i + 1];
@@ -54,6 +55,21 @@ export function revealCompletedBoundaries(batch) {
       // We may have client-rendered this boundary already. Skip it.
       continue;
     }
+
+    const parentRect = parentInstance.getBoundingClientRect();
+    if (
+      !parentRect.left &&
+      !parentRect.top &&
+      !parentRect.width &&
+      !parentRect.height
+    ) {
+      // If the parent instance is display: none then we don't consider this for the "$RT" time which was the last time we "showed content"
+      // to use for the 300ms throttle. Using the same logic we use for the ViewTransitions version below.
+    } else if(!hasUpdatedRevealTime) {
+      window['$RT'] = performance.now();
+      hasUpdatedRevealTime = true;
+    }
+    
 
     // Find the boundary around the fallback. This is always the previous node.
     const suspenseNode = suspenseIdNode.previousSibling;


### PR DESCRIPTION
When setting the timeout for revealing completed boundaries, we should not be adding the 300ms throttle for "the last time we revealed a  boundary" if the boundary we revealed was just moved inside of a "still suspended" boundary. Using the same logic here as what we do for View Transitions to determine if ParentInstance is a "hidden" boundary to avoid animation.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
